### PR TITLE
Stringy metadata

### DIFF
--- a/crates/dotnet-bindgen-cli/Cargo.toml
+++ b/crates/dotnet-bindgen-cli/Cargo.toml
@@ -9,3 +9,4 @@ dotnet-bindgen-core = { path = "../dotnet-bindgen-core" }
 goblin = "0.0.24"
 heck = "0.3"
 clap = "2.33"
+serde_json = "1.0"

--- a/crates/dotnet-bindgen-cli/src/ast.rs
+++ b/crates/dotnet-bindgen-cli/src/ast.rs
@@ -70,13 +70,13 @@ impl AstNode for FfiType {
     }
 }
 
-pub struct Root<'a> {
+pub struct Root {
     pub file_comment: Option<BlockComment>,
     pub using_statements: Vec<UsingStatement>,
-    pub children: Vec<Box<dyn AstNode + 'a>>,
+    pub children: Vec<Box<dyn AstNode>>,
 }
 
-impl<'a> Root<'a> {
+impl Root {
     pub fn render(&self, f: &mut dyn io::Write) -> Result<(), io::Error> {
         let ctx = RenderContext::default();
 
@@ -138,12 +138,12 @@ impl AstNode for UsingStatement {
     }
 }
 
-pub struct Namespace<'a> {
+pub struct Namespace {
     pub name: String,
-    pub children: Vec<Box<dyn AstNode + 'a>>,
+    pub children: Vec<Box<dyn AstNode>>,
 }
 
-impl<'a> AstNode for Namespace<'a> {
+impl AstNode for Namespace {
     fn render(&self, f: &mut dyn io::Write, ctx: RenderContext) -> Result<(), io::Error> {
         render_ln!(f, &ctx, "namespace {}", self.name)?;
         render_ln!(f, &ctx, "{{")?;
@@ -158,18 +158,18 @@ impl<'a> AstNode for Namespace<'a> {
     }
 }
 
-pub struct ImportedMethod<'a> {
+pub struct ImportedMethod {
     pub binary_name: String,
-    pub func_data: BindgenFunction<'a>,
+    pub func_data: BindgenFunction,
 }
 
-impl<'a> ImportedMethod<'a> {
+impl ImportedMethod {
     fn csharp_name(&self) -> String {
         self.func_data.name.to_camel_case()
     }
 }
 
-impl<'a> AstNode for ImportedMethod<'a> {
+impl AstNode for ImportedMethod {
     fn render(&self, f: &mut dyn io::Write, ctx: RenderContext) -> Result<(), io::Error> {
         render_ln!(f, &ctx, "[DllImport(\"{}\", EntryPoint = \"{}\")]", self.binary_name, self.func_data.name)?;
 
@@ -197,13 +197,13 @@ impl<'a> AstNode for ImportedMethod<'a> {
     }
 }
 
-pub struct Class<'a> {
+pub struct Class {
     pub name: String,
-    pub methods: Vec<ImportedMethod<'a>>,
+    pub methods: Vec<ImportedMethod>,
     pub is_static: bool
 }
 
-impl<'a> AstNode for Class<'a> {
+impl AstNode for Class {
     fn render(&self, f: &mut dyn io::Write, ctx: RenderContext) -> Result<(), io::Error> {
         let static_part = if self.is_static { "static " } else { "" };
         render_ln!(f, &ctx, "public {}class {}", static_part, self.name)?;

--- a/crates/dotnet-bindgen-cli/src/ast.rs
+++ b/crates/dotnet-bindgen-cli/src/ast.rs
@@ -54,15 +54,21 @@ impl AstNode for FfiType {
         match self {
             FfiType::Int { width, signed } => {
                 match width {
-                    8 => if *signed { write!(f, "SByte")?; } else { write!(f, "Byte")?; }
-                    16 | 32 | 64 =>  {
+                    8 => {
+                        if *signed {
+                            write!(f, "SByte")?;
+                        } else {
+                            write!(f, "Byte")?;
+                        }
+                    }
+                    16 | 32 | 64 => {
                         let base = if *signed { "Int" } else { "UInt" };
                         write!(f, "{}{}", base, width)?;
-                    },
+                    }
                     // TODO: technically not unreachable, should return a sensible error.
                     _ => unreachable!(),
                 }
-            },
+            }
             FfiType::Void => write!(f, "void")?,
         };
 
@@ -86,7 +92,7 @@ impl Root {
             Some(c) => {
                 c.render(f, ctx.clone())?;
                 first = false;
-            },
+            }
             None => (),
         }
 
@@ -171,7 +177,13 @@ impl ImportedMethod {
 
 impl AstNode for ImportedMethod {
     fn render(&self, f: &mut dyn io::Write, ctx: RenderContext) -> Result<(), io::Error> {
-        render_ln!(f, &ctx, "[DllImport(\"{}\", EntryPoint = \"{}\")]", self.binary_name, self.func_data.name)?;
+        render_ln!(
+            f,
+            &ctx,
+            "[DllImport(\"{}\", EntryPoint = \"{}\")]",
+            self.binary_name,
+            self.func_data.name
+        )?;
 
         render_indent(f, &ctx)?;
 
@@ -200,7 +212,7 @@ impl AstNode for ImportedMethod {
 pub struct Class {
     pub name: String,
     pub methods: Vec<ImportedMethod>,
-    pub is_static: bool
+    pub is_static: bool,
 }
 
 impl AstNode for Class {

--- a/crates/dotnet-bindgen-cli/src/codegen.rs
+++ b/crates/dotnet-bindgen-cli/src/codegen.rs
@@ -10,11 +10,10 @@ fn create_csproj(data: &BindgenData, project_dir: &Path) -> Result<(), std::io::
     // Generate the proj filename
     // ./foo/bar/libtest_lib.so -> TestLibBindings.csproj
 
-    let source_ext = data.source_file
-        .extension()
-        .and_then(|e| e.to_str());
+    let source_ext = data.source_file.extension().and_then(|e| e.to_str());
 
-    let source_stem = data.source_file
+    let source_stem = data
+        .source_file
         .file_stem()
         .expect("Source file path doesn't have a filename")
         .to_str()
@@ -26,7 +25,8 @@ fn create_csproj(data: &BindgenData, project_dir: &Path) -> Result<(), std::io::
         source_stem.chars().skip(3).collect::<String>()
     } else {
         source_stem.into()
-    }.to_camel_case();
+    }
+    .to_camel_case();
 
     let csproj_filename = project_dir.join(format!("{}Bindings.csproj", base_name));
 
@@ -46,48 +46,46 @@ fn create_csproj(data: &BindgenData, project_dir: &Path) -> Result<(), std::io::
 pub fn create_project(data: crate::data::BindgenData, project_dir: PathBuf) -> Result<(), ()> {
     create_csproj(&data, &project_dir).unwrap();
 
-    let binary_name = data.source_file.file_name()
+    let binary_name = data
+        .source_file
+        .file_name()
         .expect("Expect a filename in the path".into())
         .to_str()
         .expect("Expec the filename to be valid unicode");
 
     // For the first pass, stick everything in one file
     let root = ast::Root {
-        file_comment: Some(
-            ast::BlockComment {
-                text: vec![
-                    "This is a generated file, do not modify by hand.".into(),
-                ]
-            }
-        ),
+        file_comment: Some(ast::BlockComment {
+            text: vec!["This is a generated file, do not modify by hand.".into()],
+        }),
         using_statements: vec![
-            ast::UsingStatement { path: "System".into() },
-            ast::UsingStatement { path: "System.Runtime.InteropServices".into() },
+            ast::UsingStatement {
+                path: "System".into(),
+            },
+            ast::UsingStatement {
+                path: "System.Runtime.InteropServices".into(),
+            },
         ],
-        children: vec![
-            Box::new(ast::Namespace {
-                name: "Test.Namespace".into(),
-                children: vec![
-                    Box::new(ast::Class {
-                        name: "Imports".into(),
-                        is_static: true,
-                        methods: vec![
-                            ast::ImportedMethod {
-                                binary_name: binary_name.into(),
-                                func_data: data.get_function().clone(),
-                            }
-                        ]
-                    })
-                ]
-            }),
-        ]
+        children: vec![Box::new(ast::Namespace {
+            name: "Test.Namespace".into(),
+            children: vec![Box::new(ast::Class {
+                name: "Imports".into(),
+                is_static: true,
+                methods: vec![ast::ImportedMethod {
+                    binary_name: binary_name.into(),
+                    func_data: data.get_function().clone(),
+                }],
+            })],
+        })],
     };
 
     fs::create_dir_all(&project_dir).unwrap();
 
     let file_path = project_dir.join("Bindings.cs");
-    let mut file = std::fs::File::create(&file_path)
-        .expect(&format!("Can't open {} for writing", file_path.to_str().unwrap()));
+    let mut file = std::fs::File::create(&file_path).expect(&format!(
+        "Can't open {} for writing",
+        file_path.to_str().unwrap()
+    ));
     root.render(&mut file).unwrap();
 
     Ok(())

--- a/crates/dotnet-bindgen-cli/src/data.rs
+++ b/crates/dotnet-bindgen-cli/src/data.rs
@@ -41,7 +41,7 @@ impl LoadedSection {
 pub struct BindgenData {
     pub source_file: std::path::PathBuf,
 
-    loaded_func: BindgenFunction
+    loaded_func: BindgenFunction,
 }
 
 impl BindgenData {
@@ -53,7 +53,10 @@ impl BindgenData {
         let loaded_func = serde_json::from_str(metadata_string)
             .expect("Expected valid json data in bindgen data section");
 
-        Ok(Self { source_file, loaded_func })
+        Ok(Self {
+            source_file,
+            loaded_func,
+        })
     }
 
     pub fn load(file: std::path::PathBuf) -> Result<Self, ()> {

--- a/crates/dotnet-bindgen-cli/src/main.rs
+++ b/crates/dotnet-bindgen-cli/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use clap::{Arg, App};
+use clap::{App, Arg};
 
 mod ast;
 mod codegen;
@@ -12,21 +12,24 @@ fn main() {
     let matches = App::new("dotnet-bindgen-cli tool")
         .author("Joe Roberts")
         .about("Extract binding data from annotated binaries + generate dotnet bindings")
-        .arg(Arg::with_name("bin")
-            .required(true)
-            .long("bin")
-            .value_name("BIN")
-            .help("The path to the binay to process")
-            .takes_value(true)
+        .arg(
+            Arg::with_name("bin")
+                .required(true)
+                .long("bin")
+                .value_name("BIN")
+                .help("The path to the binay to process")
+                .takes_value(true),
         )
         .get_matches();
 
-
     // Safe to unwrap because --bin is a required arg
-    let binary_path = Path::new(matches.value_of("bin").unwrap()).canonicalize().unwrap();
-    let generated_poject_dir = binary_path.parent()
-            .unwrap_or(Path::new("."))
-            .join(Path::new("dotnet_bindgen"));
+    let binary_path = Path::new(matches.value_of("bin").unwrap())
+        .canonicalize()
+        .unwrap();
+    let generated_poject_dir = binary_path
+        .parent()
+        .unwrap_or(Path::new("."))
+        .join(Path::new("dotnet_bindgen"));
 
     let data = BindgenData::load(binary_path.clone()).unwrap();
 

--- a/crates/dotnet-bindgen-core/Cargo.toml
+++ b/crates/dotnet-bindgen-core/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Joe Roberts <joe@jwjr.co.uk>"]
 edition = "2018"
 
 [dependencies]
-serde = { "version" = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/dotnet-bindgen-core/Cargo.toml
+++ b/crates/dotnet-bindgen-core/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Joe Roberts <joe@jwjr.co.uk>"]
 edition = "2018"
 
 [dependencies]
+serde = { "version" = "1.0", features = ["derive"] }

--- a/crates/dotnet-bindgen-core/src/lib.rs
+++ b/crates/dotnet-bindgen-core/src/lib.rs
@@ -6,92 +6,7 @@ use std::fmt::{Debug, Display};
 use std::ops::Deref;
 use std::str::FromStr;
 
-/// Abstraction over the two useful ways of representing arrays in bindgen data
-///
-/// # Motivation
-///
-/// When dumping data into the binary, we want tight control of where the bytes
-/// live, but managing references is super tricky when generating these structs
-///  -> Use the owned variant for easy generation of the data
-///  -> Use the reference variant for serialising/parsing the structures into link sections
-///
-/// # Examples
-///
-/// ```
-/// // The array [1, 2, 3] lives somewhere on the heap
-/// // Can't initialise a static variable like this.
-/// let a = MaybeOwnedArr::Owned(vec![1, 2, 3]);
-/// ```
-///
-/// ```
-/// // Statically data that will be written to a well defined binary section
-/// #[link_section(".foo")]
-/// pub static DATA: [i32; 3] = [1, 2, 3];
-///
-/// #[no_mangle]
-/// pub static ARR: MaybeOwnedArr<'static, i32> = MaybeOwnedArr::Ref(&DATA);
-/// ```
-#[derive(Debug, Clone)]
-#[repr(C)]
-pub enum MaybeOwnedArr<'a, T> {
-    Owned(Vec<T>),
-    Ref(&'a [T]),
-}
-
-impl<'a, T> Deref for MaybeOwnedArr<'a, T> {
-    type Target = [T];
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            MaybeOwnedArr::Ref(r) => r,
-            MaybeOwnedArr::Owned(v) => &v[..],
-        }
-    }
-}
-
-/// Thin wrapper around MaybeOwnedArr for strings
-#[derive(Clone)]
-#[repr(C)]
-pub struct MaybeOwnedString<'a> {
-    pub bytes: MaybeOwnedArr<'a, u8>,
-}
-
-impl<'a> Display for MaybeOwnedString<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let parsed_str =
-            std::str::from_utf8(&self.bytes).expect("MaybeOwnedString contains non-utf8 data");
-        write!(f, "{}", parsed_str)
-    }
-}
-
-impl<'a> Debug for MaybeOwnedString<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let parsed_str =
-            std::str::from_utf8(&self.bytes).expect("MaybeOwnedString contains non-utf8 data");
-
-        match self.bytes {
-            MaybeOwnedArr::Owned(_) => write!(f, "MaybeOwnedString::Owned({:?})", parsed_str),
-            MaybeOwnedArr::Ref(_) => write!(f, "MaybeOwnedString::Ref({:?})", parsed_str),
-        }
-    }
-}
-
-impl<'a> FromStr for MaybeOwnedString<'a> {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = MaybeOwnedArr::Owned(s.as_bytes().to_vec());
-        Ok(MaybeOwnedString { bytes })
-    }
-}
-
-impl<'a> Deref for MaybeOwnedString<'a> {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        std::str::from_utf8(&self.bytes).expect("MaybeOwnedString contains non-utf8 data")
-    }
-}
+use serde::{Serialize, Deserialize};
 
 #[derive(Debug)]
 pub enum BindgenCoreErr {
@@ -99,7 +14,7 @@ pub enum BindgenCoreErr {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum FfiType {
     Int { width: u8, signed: bool },
     Void,
@@ -126,17 +41,17 @@ impl FromStr for FfiType {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone)]
-pub struct MethodArgument<'a> {
-    pub name: MaybeOwnedString<'a>,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MethodArgument {
+    pub name: String,
     pub ffi_type: FfiType,
 }
 
 #[repr(C)]
-#[derive(Debug, Clone)]
-pub struct BindgenFunction<'a> {
-    pub name: MaybeOwnedString<'a>,
-    pub args: MaybeOwnedArr<'a, MethodArgument<'a>>,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BindgenFunction {
+    pub name: String,
+    pub args: Vec<MethodArgument>,
     pub return_type: FfiType,
 }
 

--- a/crates/dotnet-bindgen-core/src/lib.rs
+++ b/crates/dotnet-bindgen-core/src/lib.rs
@@ -4,7 +4,7 @@
 
 use std::str::FromStr;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub enum BindgenCoreErr {
@@ -23,14 +23,38 @@ impl FromStr for FfiType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let ty = match s {
-            "i8" => FfiType::Int { width: 8, signed: true },
-            "i16" => FfiType::Int { width: 16, signed: true },
-            "i32" => FfiType::Int { width: 32, signed: true },
-            "i64" => FfiType::Int { width: 64, signed: true },
-            "u8" => FfiType::Int { width: 8, signed: false },
-            "u16" => FfiType::Int { width: 16, signed: false },
-            "u32" => FfiType::Int { width: 32, signed: false },
-            "u64" => FfiType::Int { width: 64, signed: false },
+            "i8" => FfiType::Int {
+                width: 8,
+                signed: true,
+            },
+            "i16" => FfiType::Int {
+                width: 16,
+                signed: true,
+            },
+            "i32" => FfiType::Int {
+                width: 32,
+                signed: true,
+            },
+            "i64" => FfiType::Int {
+                width: 64,
+                signed: true,
+            },
+            "u8" => FfiType::Int {
+                width: 8,
+                signed: false,
+            },
+            "u16" => FfiType::Int {
+                width: 16,
+                signed: false,
+            },
+            "u32" => FfiType::Int {
+                width: 32,
+                signed: false,
+            },
+            "u64" => FfiType::Int {
+                width: 64,
+                signed: false,
+            },
             _ => return Err(BindgenCoreErr::UnknownType),
         };
 

--- a/crates/dotnet-bindgen-core/src/lib.rs
+++ b/crates/dotnet-bindgen-core/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! This component is intended to be fairly minimal, to reduce the impact of having it included in client code.
 
-use std::fmt::{Debug, Display};
-use std::ops::Deref;
 use std::str::FromStr;
 
 use serde::{Serialize, Deserialize};

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -9,3 +9,4 @@ quote = "1.0"
 syn = { version = "1.0", features = ["full", "fold"] }
 proc-macro2 = "1.0"
 dotnet-bindgen-core = { path = "../dotnet-bindgen-core" }
+serde_json = "1.0"

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -14,7 +14,7 @@ enum Export {
 impl Export {
     fn name(&self) -> String {
         match self {
-            Export::Func(f) => format!("func_{}", f.name)
+            Export::Func(f) => format!("func_{}", f.name),
         }
     }
 }


### PR DESCRIPTION
Do something less insane than the crazy binary format loading with manual application of elf relocs - serialize the binding metadata to json and dump a single big json byte string into the link section.